### PR TITLE
[Design/#132] password 타입의 폰트 설정

### DIFF
--- a/src/components/DiaryPage/InnerImg.jsx
+++ b/src/components/DiaryPage/InnerImg.jsx
@@ -53,7 +53,7 @@ function InnerImg({
       try {
         const response = await baseInstance.get(`/diaries/${diaryId}`);
         if (response.data) {
-          const responseMonth = response.data.diary_data.year_month; //diart로 오타나있는데 api 수정 후 diary로 바꿔야함
+          const responseMonth = response.data.diary_data.year_month;
 
           const month = responseMonth.split('-')[1];
           const numericMonth = month.startsWith('0')

--- a/src/components/LoginInputTypePW.jsx
+++ b/src/components/LoginInputTypePW.jsx
@@ -1,14 +1,15 @@
 import React from 'react';
 import styled from 'styled-components';
 
-const LoginInput = ({ text, handleTextChange, placeholder }) => {
+const LoginInputTypePW = ({ text, handleTextChange, placeholder, font }) => {
   return (
     <LoginInputContainer>
       <TextInput
-        type="text"
+        type="password"
         value={text}
         onChange={handleTextChange}
         placeholder={placeholder}
+        fontFamily={font}
       />
     </LoginInputContainer>
   );
@@ -36,7 +37,6 @@ const TextInput = styled.input`
   outline: none;
   text-align: left;
   padding-left: 1rem;
-  font-family: 'bmjua';
   &::placeholder {
     color: #bbb;
   }
@@ -45,4 +45,4 @@ const TextInput = styled.input`
   }
 `;
 
-export default LoginInput;
+export default LoginInputTypePW;

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -9,6 +9,7 @@ import SignInBtn from '../components/SignIn_Up';
 import SmallSketchbook from '../components/SmallSketchbook';
 import sketbook from '../assets/img/HaruConnectingBook.png';
 import LoginInput from '../components/LoginInput';
+import LoginInputTypePW from '../components/LoginInputTypePW';
 import axios from 'axios';
 import { baseInstance } from '../api/config';
 
@@ -89,15 +90,13 @@ const LoginPage = () => {
           <SmallSketchbook />
           <IdInput>
             <LoginInput
-              type="text"
               placeholder="아이디"
               text={id}
-              font={'bmjua'}
               handleTextChange={handleIdChange}
             />
           </IdInput>
           <PwInput>
-            <LoginInput
+            <LoginInputTypePW
               type="text"
               placeholder="비밀번호"
               text={password}

--- a/src/pages/SignUpPage.jsx
+++ b/src/pages/SignUpPage.jsx
@@ -9,6 +9,7 @@ import LoginInput from '../components/LoginInput';
 import { baseInstance } from '../api/config';
 import Swal from 'sweetalert2/dist/sweetalert2.js';
 import 'sweetalert2/src/sweetalert2.scss';
+import LoginInputTypePW from '../components/LoginInputTypePW';
 function SignUpPage(props) {
   const [username, setUsername] = useState('');
   const [id, setId] = useState('');
@@ -194,11 +195,9 @@ function SignUpPage(props) {
           <SmallSketchbook />
           <UsernameInput>
             <LoginInput
-              type="text"
               placeholder="닉네임"
               text={username}
               handleTextChange={handleUsernameChange}
-              font={'bmjua'}
             />
           </UsernameInput>
           <UsernameRequireText
@@ -208,10 +207,8 @@ function SignUpPage(props) {
           </UsernameRequireText>
           <IdInput>
             <LoginInput
-              type="text"
               placeholder="아이디"
               text={id}
-              font={'bmjua'}
               handleTextChange={handleIdChange}
             />
           </IdInput>
@@ -219,11 +216,10 @@ function SignUpPage(props) {
             {idComment}
           </IdRequireText>
           <PwInput>
-            <LoginInput
-              type="text"
+            <LoginInputTypePW
               placeholder="비밀번호"
               text={password}
-              font={'bmjua'}
+              font={password ? '' : 'bmjua'}
               handleTextChange={handlePasswordChange}
             />
           </PwInput>
@@ -231,8 +227,7 @@ function SignUpPage(props) {
             {pwComment}
           </PwRequireText>
           <PwMatchInput>
-            <LoginInput
-              type="password"
+            <LoginInputTypePW
               placeholder="비밀번호 확인"
               text={passwordMatch}
               font={passwordMatch ? '' : 'bmjua'}


### PR DESCRIPTION
## 📢 기능 설명
비밀번호 폰트를 bmjua를 유지시키면서 type은 password로 되도록 성공했습니다.

https://github.com/2023-Winter-techeer-Bootcamp-Team-E/frontend/assets/133188752/23f82718-9fa8-452c-b73e-975b93437c27


## 연결된 issue

close #132 
<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
