### PR TITLE
[Design/#136] : guest UI 수정

### DIFF
--- a/src/components/DiaryPage/InnerImg.jsx
+++ b/src/components/DiaryPage/InnerImg.jsx
@@ -21,13 +21,13 @@ import useTextStore from '../../stores/textStore';
 import useDalleStore from '../../stores/dalleStore';
 
 function InnerImg({
-  selectedSticker,
-  selectedTextBox,
   setSelectedSticker,
   setSelectedTextBox,
   websocket,
   diaryData,
   diaryId,
+  hostId,
+  setHostId,
 }) {
   const diaryRef = useRef(null);
   const [diaryMonth, setDiaryMonth] = useState(0);
@@ -36,7 +36,6 @@ function InnerImg({
   const stickers = useStickerStore((state) => state.stickers);
   const texts = useTextStore((state) => state.texts);
   const dalles = useDalleStore((state) => state.dalles);
-
   const [innerPage, setInnerPage] = useState(1);
   const navigate = useNavigate();
 
@@ -68,6 +67,7 @@ function InnerImg({
           const diaryBgId = response.data.diary_data.diary_bg_id;
           setInnerPage(diaryBgId);
           setHostName(response.data.nickname);
+          setHostId(response.data.login_id);
         }
       } catch (error) {
         console.log(`catch 다이어리 조회 실패 : ${error.message}`);

--- a/src/components/NavigateBar.jsx
+++ b/src/components/NavigateBar.jsx
@@ -13,6 +13,7 @@ const NavigateBar = ({ locate }) => {
   const { userInfoList } = userInfoStore;
   const navigate = useNavigate();
   const [showLoginAlert, setShowLoginAlert] = useState(false);
+  const [hostCheck, setHostCheck] = useState(true);
 
   useEffect(() => {
     const loggedInUserId = localStorage.getItem('loggedInUserId');
@@ -53,6 +54,15 @@ const NavigateBar = ({ locate }) => {
   const { id, nickname } = user;
 
   useEffect(() => {
+    console.log('id : ', user.id);
+    if (user.id == 'Guest') {
+      setHostCheck(false);
+    } else {
+      setHostCheck(true);
+    }
+  }, [user.id]);
+
+  useEffect(() => {
     const handleClickOutside = (event) => {
       if (profMenuRef.current && !profMenuRef.current.contains(event.target)) {
         setIsProfMenuOpen(false);
@@ -73,11 +83,13 @@ const NavigateBar = ({ locate }) => {
     <NavBar>
       <ProfWrapper>
         <ProfName>환영합니다. {nickname}님</ProfName>
-        <ProfArrow
-          src={arrow}
-          onClick={handleProfArrowClick}
-          isopen={isProfMenuOpen}
-        />
+        {hostCheck && (
+          <ProfArrow
+            src={arrow}
+            onClick={handleProfArrowClick}
+            isopen={isProfMenuOpen}
+          />
+        )}
       </ProfWrapper>
 
       <ProfileMenuWrapper ref={profMenuRef} isopen={isProfMenuOpen}>

--- a/src/pages/DiaryPage.jsx
+++ b/src/pages/DiaryPage.jsx
@@ -37,12 +37,13 @@ function DiaryPage() {
     useUserInfoStore();
   const userId = userInfoList.map((user) => user.id);
   const [hostCheck, setHostCheck] = useState(true);
-
+  const [hostId, setHostId] = useState('');
+  console.log('hostId : ', hostId);
   useEffect(() => {
-    if (userId == '' || userId == 'Guest') {
-      setHostCheck(false);
-    } else {
+    if (userId == hostId) {
       setHostCheck(true);
+    } else {
+      setHostCheck(false);
     }
   }, [userId]);
 
@@ -215,8 +216,6 @@ function DiaryPage() {
         </WrapperLargeSketchbook>
         <WrapperInnerImg>
           <InnerImg
-            selectedSticker={selectedSticker}
-            setSelectedSticker={setSelectedSticker}
             selectedTextBox={selectedTextBox}
             setSelectedTextBox={setSelectedTextBox}
             sharedText={sharedText}
@@ -224,6 +223,8 @@ function DiaryPage() {
             diaryMonth={selectedDateInfo.selectedMonth}
             diaryDay={selectedDateInfo.selectedDay}
             diaryId={diary_id}
+            hostId={hostId}
+            setHostId={setHostId}
           />
         </WrapperInnerImg>
         <WrapperRightSticker>

--- a/src/pages/DiaryPage.jsx
+++ b/src/pages/DiaryPage.jsx
@@ -39,11 +39,12 @@ function DiaryPage() {
   const [hostCheck, setHostCheck] = useState(true);
 
   useEffect(() => {
-    if (userId == '') {
+    if (userId == '' || userId == 'Guest') {
       setHostCheck(false);
+    } else {
+      setHostCheck(true);
     }
-  }, []);
-
+  }, [userId]);
 
   const handleTextButtonClick = () => {
     setSelectedTextBox(true);


### PR DESCRIPTION
## 📢 기능 설명

Guest 일기 작성 페이지 UI 수정했습니다.

Guest는 프로필 메뉴 토글이 비활성화 되고 일기 작성 페이지에서 저장 및 홈으로 가기 버튼이 비활성화 되도록 UI를 수정했습니다.

이 때 Guest뿐만 아니라 일기의 host가 아닌 모든 사람들은 저장 및 홈으로 가기 버튼이 비활성화 되어있습니다.

<img width="1832" alt="image" src="https://github.com/2023-Winter-techeer-Bootcamp-Team-E/frontend/assets/133188752/3d8c0bf2-ab28-4f65-b49a-ac1c31158d4b">

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #136 
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
